### PR TITLE
v1.0.6

### DIFF
--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -29,6 +29,9 @@ func main() {
 	verify := flag.Bool("verify", true, "Verify patches after creation")
 	createExe := flag.Bool("create-exe", false, "Create self-contained CLI executable")
 	crp := flag.Bool("crp", false, "Create reverse patch (for downgrades)")
+	saveScans := flag.Bool("savescans", false, "Save directory scans to cache for faster subsequent patches")
+	rescan := flag.Bool("rescan", false, "Force rescan of cached versions")
+	scanData := flag.String("scandata", "", "Custom directory for scan cache (default: .data)")
 	versionFlag := flag.Bool("version", false, "Show version information")
 	help := flag.Bool("help", false, "Show help message")
 
@@ -54,6 +57,15 @@ func main() {
 
 	// Initialize version manager
 	versionMgr := version.NewManager()
+
+	// Enable scan caching if requested
+	if *saveScans {
+		versionMgr.EnableScanCache(*scanData, *rescan)
+		fmt.Printf("✓ Scan caching enabled (cache dir: %s)\n", versionMgr.GetScanCache().GetCacheDir())
+		if *rescan {
+			fmt.Println("  Force rescan: enabled")
+		}
+	}
 
 	// Set output directory
 	outputDir := *output
@@ -640,6 +652,9 @@ func printHelp() {
 	fmt.Println("  --verify          Verify patches after creation (default: true)")
 	fmt.Println("  --create-exe      Create self-contained CLI executable")
 	fmt.Println("  --crp             Create reverse patch (for downgrades)")
+	fmt.Println("  --savescans       Save directory scans to cache for faster subsequent patches")
+	fmt.Println("  --rescan          Force rescan of cached versions (use with --savescans)")
+	fmt.Println("  --scandata        Custom directory for scan cache (default: .data)")
 	fmt.Println("  --version         Show version information")
 	fmt.Println("  --help            Show this help message")
 	fmt.Println("\nExamples:")
@@ -649,6 +664,11 @@ func printHelp() {
 	fmt.Println("  patch-gen --from-dir C:\\\\v1 --to-dir C:\\\\v2 --output patches --create-exe")
 	fmt.Println("\n  # Create forward and reverse patches with executables")
 	fmt.Println("  patch-gen --from-dir C:\\\\v1.0.0 --to-dir C:\\\\v1.0.1 --output patches --crp --create-exe")
+	fmt.Println("\n  # Use scan caching for faster subsequent patches")
+	fmt.Println("  patch-gen --versions-dir C:\\\\versions --from 1.0.0 --to 1.0.1 --output patches --savescans")
+	fmt.Println("  patch-gen --versions-dir C:\\\\versions --from 1.0.1 --to 1.0.2 --output patches --savescans")
+	fmt.Println("\n  # Force rescan of cached versions")
+	fmt.Println("  patch-gen --versions-dir C:\\\\versions --from 1.0.0 --to 1.0.1 --output patches --savescans --rescan")
 	fmt.Println("\n  # Versions on different network locations")
 	fmt.Println("  patch-gen --from-dir \\\\\\\\server1\\\\app\\\\v1 --to-dir \\\\\\\\server2\\\\app\\\\v2 --output .")
 }

--- a/internal/core/cache/scan_cache.go
+++ b/internal/core/cache/scan_cache.go
@@ -1,0 +1,258 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cyberofficial/cyberpatchmaker/pkg/utils"
+)
+
+// ScanCache manages cached directory scans
+type ScanCache struct {
+	cacheDir string
+}
+
+// NewScanCache creates a new scan cache manager
+func NewScanCache(cacheDir string) *ScanCache {
+	// If cacheDir is empty, use default .data directory in current working directory
+	if cacheDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			// Fallback to executable directory
+			exe, exeErr := os.Executable()
+			if exeErr == nil {
+				cwd = filepath.Dir(exe)
+			} else {
+				cwd = "."
+			}
+		}
+		cacheDir = filepath.Join(cwd, ".data")
+	}
+
+	return &ScanCache{
+		cacheDir: cacheDir,
+	}
+}
+
+// GetCacheDir returns the cache directory path
+func (sc *ScanCache) GetCacheDir() string {
+	return sc.cacheDir
+}
+
+// SaveScan saves a scan result to cache
+func (sc *ScanCache) SaveScan(version *utils.Version) error {
+	if version.Manifest == nil {
+		return fmt.Errorf("version manifest is nil")
+	}
+
+	// Ensure cache directory exists
+	if err := utils.EnsureDir(sc.cacheDir); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	// Generate cache filename from version number and location
+	cacheFilename := sc.generateCacheFilename(version.Number, version.Location)
+	cachePath := filepath.Join(sc.cacheDir, cacheFilename)
+
+	// Create cache entry with all necessary information
+	cacheEntry := CachedScan{
+		Version:      version.Number,
+		Location:     version.Location,
+		KeyFile:      version.KeyFile,
+		Manifest:     version.Manifest,
+		CachedAt:     version.LastScanned,
+		LocationHash: sc.hashLocation(version.Location),
+	}
+
+	// Marshal to JSON
+	data, err := json.MarshalIndent(cacheEntry, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache entry: %w", err)
+	}
+
+	// Write to file
+	if err := os.WriteFile(cachePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadScan loads a scan result from cache
+func (sc *ScanCache) LoadScan(versionNumber, location string) (*utils.Version, error) {
+	cacheFilename := sc.generateCacheFilename(versionNumber, location)
+	cachePath := filepath.Join(sc.cacheDir, cacheFilename)
+
+	// Check if cache file exists
+	if !utils.FileExists(cachePath) {
+		return nil, fmt.Errorf("no cached scan found for version %s at %s", versionNumber, location)
+	}
+
+	// Read cache file
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	// Unmarshal cache entry
+	var cacheEntry CachedScan
+	if err := json.Unmarshal(data, &cacheEntry); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cache entry: %w", err)
+	}
+
+	// Validate location hash matches
+	if cacheEntry.LocationHash != sc.hashLocation(location) {
+		return nil, fmt.Errorf("location hash mismatch - cache may be for different directory")
+	}
+
+	// Create version from cache
+	version := &utils.Version{
+		Number:       cacheEntry.Version,
+		Location:     cacheEntry.Location,
+		KeyFile:      cacheEntry.KeyFile,
+		Manifest:     cacheEntry.Manifest,
+		RegisteredAt: cacheEntry.CachedAt,
+		LastScanned:  cacheEntry.CachedAt,
+	}
+
+	return version, nil
+}
+
+// HasCachedScan checks if a cached scan exists
+func (sc *ScanCache) HasCachedScan(versionNumber, location string) bool {
+	cacheFilename := sc.generateCacheFilename(versionNumber, location)
+	cachePath := filepath.Join(sc.cacheDir, cacheFilename)
+	return utils.FileExists(cachePath)
+}
+
+// DeleteScan removes a cached scan
+func (sc *ScanCache) DeleteScan(versionNumber, location string) error {
+	cacheFilename := sc.generateCacheFilename(versionNumber, location)
+	cachePath := filepath.Join(sc.cacheDir, cacheFilename)
+
+	if !utils.FileExists(cachePath) {
+		return nil // Already deleted
+	}
+
+	if err := os.Remove(cachePath); err != nil {
+		return fmt.Errorf("failed to delete cache file: %w", err)
+	}
+
+	return nil
+}
+
+// ClearCache removes all cached scans
+func (sc *ScanCache) ClearCache() error {
+	if !utils.FileExists(sc.cacheDir) {
+		return nil // Nothing to clear
+	}
+
+	// Read all files in cache directory
+	entries, err := os.ReadDir(sc.cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to read cache directory: %w", err)
+	}
+
+	// Delete all .json cache files
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			filePath := filepath.Join(sc.cacheDir, entry.Name())
+			if err := os.Remove(filePath); err != nil {
+				return fmt.Errorf("failed to delete cache file %s: %w", entry.Name(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ListCachedScans returns a list of all cached scans
+func (sc *ScanCache) ListCachedScans() ([]CachedScanInfo, error) {
+	if !utils.FileExists(sc.cacheDir) {
+		return []CachedScanInfo{}, nil
+	}
+
+	entries, err := os.ReadDir(sc.cacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache directory: %w", err)
+	}
+
+	var cachedScans []CachedScanInfo
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		cachePath := filepath.Join(sc.cacheDir, entry.Name())
+		data, err := os.ReadFile(cachePath)
+		if err != nil {
+			continue // Skip files we can't read
+		}
+
+		var cacheEntry CachedScan
+		if err := json.Unmarshal(data, &cacheEntry); err != nil {
+			continue // Skip invalid cache files
+		}
+
+		info := CachedScanInfo{
+			Version:    cacheEntry.Version,
+			Location:   cacheEntry.Location,
+			CachedAt:   cacheEntry.CachedAt,
+			TotalFiles: cacheEntry.Manifest.TotalFiles,
+			TotalSize:  cacheEntry.Manifest.TotalSize,
+		}
+		cachedScans = append(cachedScans, info)
+	}
+
+	return cachedScans, nil
+}
+
+// generateCacheFilename creates a unique cache filename
+func (sc *ScanCache) generateCacheFilename(versionNumber, location string) string {
+	// Create a safe filename from version number and location hash
+	safeVersion := strings.ReplaceAll(versionNumber, string(filepath.Separator), "_")
+	safeVersion = strings.ReplaceAll(safeVersion, ":", "_")
+	safeVersion = strings.ReplaceAll(safeVersion, " ", "_")
+
+	locationHash := sc.hashLocation(location)[:16] // First 16 chars of hash
+
+	return fmt.Sprintf("scan_%s_%s.json", safeVersion, locationHash)
+}
+
+// hashLocation creates a consistent hash of a location path
+func (sc *ScanCache) hashLocation(location string) string {
+	// Normalize path (convert to absolute, clean, and use consistent separators)
+	absPath, err := filepath.Abs(location)
+	if err != nil {
+		absPath = location
+	}
+	absPath = filepath.Clean(absPath)
+	absPath = filepath.ToSlash(absPath)
+	absPath = strings.ToLower(absPath) // Case-insensitive
+
+	// Calculate hash
+	return utils.CalculateStringChecksum(absPath)
+}
+
+// CachedScan represents a cached scan result
+type CachedScan struct {
+	Version      string            `json:"version"`
+	Location     string            `json:"location"`
+	KeyFile      utils.KeyFileInfo `json:"key_file"`
+	Manifest     *utils.Manifest   `json:"manifest"`
+	CachedAt     time.Time         `json:"cached_at"`
+	LocationHash string            `json:"location_hash"`
+}
+
+// CachedScanInfo provides summary information about a cached scan
+type CachedScanInfo struct {
+	Version    string    `json:"version"`
+	Location   string    `json:"location"`
+	CachedAt   time.Time `json:"cached_at"`
+	TotalFiles int       `json:"total_files"`
+	TotalSize  int64     `json:"total_size"`
+}

--- a/internal/core/patcher/generator.go
+++ b/internal/core/patcher/generator.go
@@ -99,12 +99,23 @@ func (g *Generator) GeneratePatch(fromVersion, toVersion *utils.Version, options
 	}
 
 	// Process added files
-	for _, file := range added {
+	totalAdded := len(added)
+	if totalAdded > 0 {
+		fmt.Printf("Processing %d added files...\n", totalAdded)
+	}
+	for i, file := range added {
+		if totalAdded > 10 {
+			fmt.Printf("\rAdding files: %d/%d (%d%%)...", i+1, totalAdded, ((i+1)*100)/totalAdded)
+		}
+
 		fullPath := filepath.Join(toVersion.Location, file.Path)
 
 		// Read new file
 		fileData, err := os.ReadFile(fullPath)
 		if err != nil {
+			if totalAdded > 10 {
+				fmt.Println()
+			}
 			return nil, fmt.Errorf("failed to read new file %s: %w", file.Path, err)
 		}
 
@@ -116,11 +127,25 @@ func (g *Generator) GeneratePatch(fromVersion, toVersion *utils.Version, options
 			Size:        file.Size,
 		})
 
-		fmt.Printf("  Add: %s (%d bytes)\n", file.Path, file.Size)
+		if totalAdded <= 10 {
+			fmt.Printf("  Add: %s (%d bytes)\n", file.Path, file.Size)
+		}
+	}
+	if totalAdded > 10 {
+		fmt.Println()
 	}
 
 	// Process modified files
-	for _, file := range modified {
+	totalModified := len(modified)
+	if totalModified > 0 {
+		fmt.Printf("Processing %d modified files (generating diffs)...\n", totalModified)
+	}
+	processedCount := 0
+	for idx, file := range modified {
+		if totalModified > 10 {
+			fmt.Printf("\rGenerating diffs: %d/%d (%d%%)...", idx+1, totalModified, ((idx+1)*100)/totalModified)
+		}
+
 		// Find corresponding source file
 		var sourceFile *utils.FileEntry
 		for i := range fromVersion.Manifest.Files {
@@ -131,6 +156,9 @@ func (g *Generator) GeneratePatch(fromVersion, toVersion *utils.Version, options
 		}
 
 		if sourceFile == nil {
+			if totalModified > 10 {
+				fmt.Println()
+			}
 			return nil, fmt.Errorf("source file not found: %s", file.Path)
 		}
 
@@ -145,6 +173,9 @@ func (g *Generator) GeneratePatch(fromVersion, toVersion *utils.Version, options
 
 		diffData, err := g.differ.GenerateDiff(oldPath, newPath)
 		if err != nil {
+			if totalModified > 10 {
+				fmt.Println()
+			}
 			return nil, fmt.Errorf("failed to generate diff for %s: %w", file.Path, err)
 		}
 
@@ -157,8 +188,14 @@ func (g *Generator) GeneratePatch(fromVersion, toVersion *utils.Version, options
 			Size:        int64(len(diffData)),
 		})
 
-		fmt.Printf("  Modify (diff): %s (diff: %d bytes, orig: %d bytes, new: %d bytes)\n",
-			file.Path, len(diffData), sourceFile.Size, file.Size)
+		if totalModified <= 10 {
+			fmt.Printf("  Modify (diff): %s (diff: %d bytes, orig: %d bytes, new: %d bytes)\n",
+				file.Path, len(diffData), sourceFile.Size, file.Size)
+		}
+		processedCount++
+	}
+	if totalModified > 10 {
+		fmt.Println()
 	}
 
 	// Create patch header

--- a/internal/core/version/version.go
+++ b/internal/core/version/version.go
@@ -10,7 +10,7 @@ const (
 	Minor = 0
 
 	// Patch version number
-	Patch = 5
+	Patch = 6
 
 	// PreRelease suffix (e.g., "alpha", "beta", "rc1")
 	// Leave empty for stable releases

--- a/internal/core/version/version.go
+++ b/internal/core/version/version.go
@@ -10,7 +10,7 @@ const (
 	Minor = 0
 
 	// Patch version number
-	Patch = 4
+	Patch = 5
 
 	// PreRelease suffix (e.g., "alpha", "beta", "rc1")
 	// Leave empty for stable releases

--- a/pkg/utils/checksum.go
+++ b/pkg/utils/checksum.go
@@ -30,6 +30,12 @@ func CalculateDataChecksum(data []byte) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// CalculateStringChecksum computes the SHA-256 hash of a string
+func CalculateStringChecksum(text string) string {
+	hash := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(hash[:])
+}
+
 // VerifyFileChecksum verifies a file's checksum matches the expected value
 func VerifyFileChecksum(filePath string, expectedChecksum string) (bool, error) {
 	actualChecksum, err := CalculateFileChecksum(filePath)


### PR DESCRIPTION
This pull request introduces a major new feature: directory scan caching for faster patch generation, along with improvements to progress reporting and usability enhancements. The scan caching system allows previously scanned directory states to be saved and reused, significantly reducing the time required for subsequent patch operations. The CLI now supports new flags to control caching behavior, and progress output for both scanning and patch generation has been improved for better user experience.

**Scan Caching Feature:**

* Added a new `ScanCache` manager (`internal/core/cache/scan_cache.go`) that can save, load, list, and clear cached directory scans, using a customizable cache directory and robust file validation.
* Integrated scan caching into the version manager (`internal/core/version/manager.go`): added methods to enable caching, use cached scans when available, and save new scans to cache after registration. [[1]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R20-R22) [[2]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R39-R59) [[3]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R75-R135) [[4]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R170-R178)

**CLI Enhancements:**

* Added new flags to the CLI (`cmd/generator/main.go`): `--savescans`, `--rescan`, and `--scandata` for controlling scan caching, with updated help messages and practical usage examples. [[1]](diffhunk://#diff-f59d142a3ad45f7a7bb182ca95d3d7130496d5269597d8217bb1ec16b63295cbR32-R34) [[2]](diffhunk://#diff-f59d142a3ad45f7a7bb182ca95d3d7130496d5269597d8217bb1ec16b63295cbR655-R657) [[3]](diffhunk://#diff-f59d142a3ad45f7a7bb182ca95d3d7130496d5269597d8217bb1ec16b63295cbR667-R671)
* When scan caching is enabled, the CLI prints informative messages about cache usage and status.

**Progress Reporting Improvements:**

* Directory scanning now displays real-time progress, including percentage, elapsed time, and estimated time remaining, both during initial registration and rescans. [[1]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R75-R135) [[2]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19L154-R260) [[3]](diffhunk://#diff-ff785644fcd36056dc0987ca8e01c789ef4e1f0abfa50f8ea37a381990e06b19R390-R412)
* Patch generation for large sets of files now includes progress indicators for added and modified files, improving feedback for lengthy operations. [[1]](diffhunk://#diff-263714db6b90d1829e91f23a547021292f92d4ffb7d829a8c6e3ce037b7be29aL102-R118) [[2]](diffhunk://#diff-263714db6b90d1829e91f23a547021292f92d4ffb7d829a8c6e3ce037b7be29aR130-R148) [[3]](diffhunk://#diff-263714db6b90d1829e91f23a547021292f92d4ffb7d829a8c6e3ce037b7be29aR159-R161) [[4]](diffhunk://#diff-263714db6b90d1829e91f23a547021292f92d4ffb7d829a8c6e3ce037b7be29aR176-R178) [[5]](diffhunk://#diff-263714db6b90d1829e91f23a547021292f92d4ffb7d829a8c6e3ce037b7be29aR191-R199)

**Version Update:**

* Bumped the patch version number from 4 to 6 in `internal/core/version/version.go`.